### PR TITLE
Add log tracking migration script

### DIFF
--- a/scripts/fluentd-log-tracking-migration.sh
+++ b/scripts/fluentd-log-tracking-migration.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Author: artheus
+#
+# Simple migration script for migrating log-tracking data from FluentD instances to
+# fluent-bit SQLite3 DB.
+#
+# This will only look for the fluentd-containers.log.pos file, and migrate any data
+# from within that file. If no fluent-bit SQLite3 DB exists, this script will create
+# one, and input any data from the FluentD container log tracking file.
+#
+
+info() {
+  printf "[%s] INFO - %s\n" "$(date --iso-8601=seconds )" "$@"
+}
+
+readonly DB='/opt/fluent-bit-db/log-tracking.db'
+readonly FLUENTD_LOG_POS="/var/log/fluentd-containers.log.pos"
+
+if [[ ! -f "$FLUENTD_LOG_POS" ]]; then
+  info "No FluentD log tracking file to migrate from, no migration done"
+  exit
+fi
+
+if [[ ! -f "$DB" ]]; then
+  sqlite3 "$DB" "CREATE TABLE main.in_tail_files (id INTEGER PRIMARY KEY, name TEXT, offset INTEGER, inode INTEGER, created INTEGER, rotated INTEGER);"
+else
+  info "fluent-bit database already exists, will not do migration"
+  exit
+fi
+
+while read -r line; do
+  IFS=$'\t' read -r -a parts <<< "$line"
+
+  filename="${parts[0]}"
+  offset="$((16#${parts[1]}))"
+  inode="$((16#${parts[2]}))"
+  now="$(date +%s)"
+
+  sqlite3 "$DB" "INSERT INTO in_tail_files (name, offset, inode, created, rotated) VALUES ('$filename', $offset, $inode, $now, 0)"
+done < <(sort "$FLUENTD_LOG_POS")


### PR DESCRIPTION
A simple bash script, using the sqlite3 executable, to migrate log tracking information from FluentD to
fluent-bit SQLite DB.

Just a simple utility script I wrote, which hopefully can help others with the need for migrating the log tracking information from FluentD to fluent-bit.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
_**Documentation is not necessarily required for this, but might be a nice-to-have. At least, maybe, a mention of that such a script exists, if anyone would ever need it.**_

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
